### PR TITLE
[RPA-1309] Export to HTML action now keeps cell formatting

### DIFF
--- a/office-actions/package.json
+++ b/office-actions/package.json
@@ -1,6 +1,6 @@
 {
     "name": "office-actions",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "type": "commonjs",
     "main": "dist/index.js",
     "module": "./dist/index.js",

--- a/office-actions/src/automation/excel/excel.action-handler.ts
+++ b/office-actions/src/automation/excel/excel.action-handler.ts
@@ -334,8 +334,8 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             throw new Error(ExcelErrorMessage.createHtmlTableInvalidRangeFormat());
         }
 
-        const splitCellRange = input.cellRange.split(':');
-        const isSingleCellRange = splitCellRange[0] === splitCellRange[1];
+        const [startCell, endCell] = input.cellRange.split(':');
+        const isSingleCellRange = startCell === endCell;
         if (isSingleCellRange) {
             throw new Error(ExcelErrorMessage.createHtmlTableInvalidCellRange());
         }
@@ -350,25 +350,34 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             throw new Error(ExcelErrorMessage.createHtmlTableInvalidRowLevel());
         }
 
+        const rowLevel = input.rowLevel ? Number(input.rowLevel) : 1;
+
         const headerRow = input.headerRow;
         if (headerRow && (Number(headerRow) <= 0 || Number(headerRow) > rowsCount)) {
             throw new Error(ExcelErrorMessage.createHtmlTableInvalidRow());
         }
 
         const rangeValues = [];
-        const startCell = splitCellRange[0]
-        const endCell = splitCellRange[1]
+
         const { column: startColumn, row: startRow } = this.getDividedCellCoordinates(startCell);
         const { column: endColumn, row: endRow } = this.getDividedCellCoordinates(endCell);
 
         for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
+            const rowOutlineLevel = rowsRange.Rows(rowIdx).OutlineLevel;
+            if (rowOutlineLevel > rowLevel) {
+                continue;
+            };
+            
             const rowValues: ExcelCellValue[] = [];
+         
             for (let columnIdx = startColumn; columnIdx <= endColumn; columnIdx++) {
                 rowValues.push(targetWorksheet.Cells(rowIdx, columnIdx).Text ?? '');
             }
+
             rangeValues.push(rowValues);
         }
 
+        console.log(rangeValues);
         const htmlTable = this.createHtmlTable(rangeValues, headerRow);
 
         return htmlTable;

--- a/office-actions/src/automation/excel/excel.action-handler.ts
+++ b/office-actions/src/automation/excel/excel.action-handler.ts
@@ -364,9 +364,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
 
         for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
             const rowOutlineLevel = rowsRange.Rows(rowIdx).OutlineLevel;
-            if (rowOutlineLevel > rowLevel) {
-                continue;
-            };
+            if (rowOutlineLevel > rowLevel) continue;
             
             const rowValues: ExcelCellValue[] = [];
          
@@ -377,7 +375,6 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             rangeValues.push(rowValues);
         }
 
-        console.log(rangeValues);
         const htmlTable = this.createHtmlTable(rangeValues, headerRow);
 
         return htmlTable;

--- a/office-actions/src/automation/excel/excel.action-handler.ts
+++ b/office-actions/src/automation/excel/excel.action-handler.ts
@@ -364,7 +364,6 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
             const rowValues: ExcelCellValue[] = [];
             for (let columnIdx = startColumn; columnIdx <= endColumn; columnIdx++) {
-                console.log(`${rowIdx} ${columnIdx}:`, targetWorksheet.Cells(rowIdx, columnIdx).Text ?? '');
                 rowValues.push(targetWorksheet.Cells(rowIdx, columnIdx).Text ?? '');
             }
             rangeValues.push(rowValues);

--- a/office-actions/src/automation/excel/excel.action-handler.ts
+++ b/office-actions/src/automation/excel/excel.action-handler.ts
@@ -41,7 +41,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async open(input: ExcelOpenActionInput): Promise<void> {
         const winax = await import('@runbotics/winax');
         this.session = new winax.Object('Excel.Application', {
-            activate: true,
+            activate: true
         });
         this.session.Workbooks.Open(input.path);
         this.session.Visible = true;
@@ -106,9 +106,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async setCell(input: ExcelSetCellActionInput): Promise<void> {
         if (input.worksheet) this.checkIsWorksheetNameCorrect(input.worksheet, true);
         try {
-            const cell = this.session
-                .Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name)
-                .Range(input.targetCell);
+            const cell = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name).Range(input.targetCell);
 
             cell.Value = input.value;
         } catch (e) {
@@ -211,9 +209,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             const amount = input.amount;
             if (this.isNegativeInteger(amount)) throw new Error();
 
-            targetWorksheet
-                .Range(targetWorksheet.Columns(column), targetWorksheet.Columns(column + amount - 1))
-                .Insert();
+            targetWorksheet.Range(targetWorksheet.Columns(column), targetWorksheet.Columns(column + amount - 1)).Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput());
         }
@@ -228,9 +224,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             const amount = input.amount;
             if (this.isNegativeInteger(amount)) throw new Error();
 
-            targetWorksheet
-                .Range(targetWorksheet.Columns(column + 1), targetWorksheet.Columns(column + amount))
-                .Insert();
+            targetWorksheet.Range(targetWorksheet.Columns(column + 1), targetWorksheet.Columns(column + amount)).Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput());
         }
@@ -247,9 +241,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
 
         try {
-            targetWorksheet
-                .Range(targetWorksheet.Rows(startingRow), targetWorksheet.Rows(startingRow + rowsNumber - 1))
-                .Insert();
+            targetWorksheet.Range(targetWorksheet.Rows(startingRow), targetWorksheet.Rows(startingRow + rowsNumber - 1)).Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertRowsIncorrectInput());
         }
@@ -283,9 +275,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
 
         try {
-            targetWorksheet
-                .Range(targetWorksheet.Rows(startingRow + 1), targetWorksheet.Rows(startingRow + rowsNumber))
-                .Insert();
+            targetWorksheet.Range(targetWorksheet.Rows(startingRow + 1), targetWorksheet.Rows(startingRow + rowsNumber)).Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertRowsIncorrectInput());
         }
@@ -364,12 +354,11 @@ export default class ExcelActionHandler extends StatefulActionHandler {
 
         for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
             const rowOutlineLevel = rowsRange.Rows(rowIdx).OutlineLevel;
-            if (rowOutlineLevel > rowLevel) {
-                continue;
-            };
+
+            if (rowOutlineLevel > rowLevel) continue;
             
             const rowValues: ExcelCellValue[] = [];
-         
+
             for (let columnIdx = startColumn; columnIdx <= endColumn; columnIdx++) {
                 rowValues.push(targetWorksheet.Cells(rowIdx, columnIdx).Text ?? '');
             }
@@ -377,7 +366,6 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             rangeValues.push(rowValues);
         }
 
-        console.log(rangeValues);
         const htmlTable = this.createHtmlTable(rangeValues, headerRow);
 
         return htmlTable;
@@ -387,9 +375,12 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         const headerRow = row && Number(row) > 0 ? Number(row) - 1 : 0;
         const headers = data[headerRow];
 
-        const tableStyle = 'overflow: auto; border: 1px solid #dededf; height: 100%; table-layout: auto; border-collapse: collapse; border-spacing: 1px;';
-        const thStyle = 'border: 1px solid #dededf; background-color: #eceff1; color: #000000; padding: 5px 15px; text-align: left; height: 20.4pt; white-space: nowrap;';
-        const tdStyle = 'border: 1px solid #dededf; background-color: #ffffff; color: #000000; padding: 5px 15px; text-align: left; height: 14.4pt; white-space: nowrap;';
+        const tableStyle =
+            'overflow: auto; border: 1px solid #dededf; height: 100%; table-layout: auto; border-collapse: collapse; border-spacing: 1px;';
+        const thStyle =
+            'border: 1px solid #dededf; background-color: #eceff1; color: #000000; padding: 5px 15px; text-align: left; height: 20.4pt; white-space: nowrap;';
+        const tdStyle =
+            'border: 1px solid #dededf; background-color: #ffffff; color: #000000; padding: 5px 15px; text-align: left; height: 14.4pt; white-space: nowrap;';
 
         let tableHtml = `<table style="${tableStyle}"><thead><tr>`;
 
@@ -459,12 +450,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             case 2:
                 return this.session.Run(input.macro, input.functionParams[0], input.functionParams[1]);
             case 3:
-                return this.session.Run(
-                    input.macro,
-                    input.functionParams[0],
-                    input.functionParams[1],
-                    input.functionParams[2]
-                );
+                return this.session.Run(input.macro, input.functionParams[0], input.functionParams[1], input.functionParams[2]);
             case 4:
                 return this.session.Run(
                     input.macro,
@@ -633,9 +619,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         if (
             (shouldExist && !this.checkIfWorksheetExist(worksheet)) ||
             (!shouldExist &&
-                (this.checkIfWorksheetExist(worksheet) ||
-                    worksheet.length > 31 ||
-                    !worksheet.match(RegexPatterns.EXCEL_WORKSHEET_NAME)))
+                (this.checkIfWorksheetExist(worksheet) || worksheet.length > 31 || !worksheet.match(RegexPatterns.EXCEL_WORKSHEET_NAME)))
         ) {
             throw new Error(ExcelErrorMessage.worksheetIncorrectInput(shouldExist));
         }
@@ -650,12 +634,11 @@ export default class ExcelActionHandler extends StatefulActionHandler {
      */
     private getDividedCellCoordinates(cell: string): CellCoordinates {
         const cellMatch = cell.match(/([A-Z]+)([0-9]+)/);
-        if (!cellMatch || cellMatch.length !== 3)
-            throw new Error(ExcelErrorMessage.divideCellCoordinatesIncorrectInput());
+        if (!cellMatch || cellMatch.length !== 3) throw new Error(ExcelErrorMessage.divideCellCoordinatesIncorrectInput());
 
         return {
             column: this.getColumnCoordinate(cellMatch[1]),
-            row: Number(cellMatch[2]),
+            row: Number(cellMatch[2])
         };
     }
 
@@ -666,8 +649,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
      * @example getColumnCoordinate('C') // 3
      */
     private getColumnCoordinate(column: string): number {
-        if (!column || typeof column === 'number')
-            throw new Error(ExcelErrorMessage.getColumnCoordinateIncorrectInput());
+        if (!column || typeof column === 'number') throw new Error(ExcelErrorMessage.getColumnCoordinateIncorrectInput());
         return this.session.ActiveSheet.Range(`${column}1`).Column;
     }
 
@@ -748,6 +730,6 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     }
 
     private isNegativeInteger(number: number): boolean {
-        return (Number.isInteger(number) && number < 0)
+        return Number.isInteger(number) && number < 0;
     }
 }

--- a/office-actions/src/automation/excel/excel.action-handler.ts
+++ b/office-actions/src/automation/excel/excel.action-handler.ts
@@ -41,7 +41,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async open(input: ExcelOpenActionInput): Promise<void> {
         const winax = await import('@runbotics/winax');
         this.session = new winax.Object('Excel.Application', {
-            activate: true
+            activate: true,
         });
         this.session.Workbooks.Open(input.path);
         this.session.Visible = true;
@@ -106,7 +106,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     async setCell(input: ExcelSetCellActionInput): Promise<void> {
         if (input.worksheet) this.checkIsWorksheetNameCorrect(input.worksheet, true);
         try {
-            const cell = this.session.Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name).Range(input.targetCell);
+            const cell = this.session
+                .Worksheets(input?.worksheet ?? this.session.ActiveSheet.Name)
+                .Range(input.targetCell);
 
             cell.Value = input.value;
         } catch (e) {
@@ -209,7 +211,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             const amount = input.amount;
             if (this.isNegativeInteger(amount)) throw new Error();
 
-            targetWorksheet.Range(targetWorksheet.Columns(column), targetWorksheet.Columns(column + amount - 1)).Insert();
+            targetWorksheet
+                .Range(targetWorksheet.Columns(column), targetWorksheet.Columns(column + amount - 1))
+                .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput());
         }
@@ -224,7 +228,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             const amount = input.amount;
             if (this.isNegativeInteger(amount)) throw new Error();
 
-            targetWorksheet.Range(targetWorksheet.Columns(column + 1), targetWorksheet.Columns(column + amount)).Insert();
+            targetWorksheet
+                .Range(targetWorksheet.Columns(column + 1), targetWorksheet.Columns(column + amount))
+                .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertColumnsIncorrectInput());
         }
@@ -241,7 +247,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
 
         try {
-            targetWorksheet.Range(targetWorksheet.Rows(startingRow), targetWorksheet.Rows(startingRow + rowsNumber - 1)).Insert();
+            targetWorksheet
+                .Range(targetWorksheet.Rows(startingRow), targetWorksheet.Rows(startingRow + rowsNumber - 1))
+                .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertRowsIncorrectInput());
         }
@@ -275,7 +283,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         }
 
         try {
-            targetWorksheet.Range(targetWorksheet.Rows(startingRow + 1), targetWorksheet.Rows(startingRow + rowsNumber)).Insert();
+            targetWorksheet
+                .Range(targetWorksheet.Rows(startingRow + 1), targetWorksheet.Rows(startingRow + rowsNumber))
+                .Insert();
         } catch (e) {
             throw new Error(ExcelErrorMessage.insertRowsIncorrectInput());
         }
@@ -354,11 +364,12 @@ export default class ExcelActionHandler extends StatefulActionHandler {
 
         for (let rowIdx = startRow; rowIdx <= endRow; rowIdx++) {
             const rowOutlineLevel = rowsRange.Rows(rowIdx).OutlineLevel;
-
-            if (rowOutlineLevel > rowLevel) continue;
+            if (rowOutlineLevel > rowLevel) {
+                continue;
+            };
             
             const rowValues: ExcelCellValue[] = [];
-
+         
             for (let columnIdx = startColumn; columnIdx <= endColumn; columnIdx++) {
                 rowValues.push(targetWorksheet.Cells(rowIdx, columnIdx).Text ?? '');
             }
@@ -366,6 +377,7 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             rangeValues.push(rowValues);
         }
 
+        console.log(rangeValues);
         const htmlTable = this.createHtmlTable(rangeValues, headerRow);
 
         return htmlTable;
@@ -375,12 +387,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         const headerRow = row && Number(row) > 0 ? Number(row) - 1 : 0;
         const headers = data[headerRow];
 
-        const tableStyle =
-            'overflow: auto; border: 1px solid #dededf; height: 100%; table-layout: auto; border-collapse: collapse; border-spacing: 1px;';
-        const thStyle =
-            'border: 1px solid #dededf; background-color: #eceff1; color: #000000; padding: 5px 15px; text-align: left; height: 20.4pt; white-space: nowrap;';
-        const tdStyle =
-            'border: 1px solid #dededf; background-color: #ffffff; color: #000000; padding: 5px 15px; text-align: left; height: 14.4pt; white-space: nowrap;';
+        const tableStyle = 'overflow: auto; border: 1px solid #dededf; height: 100%; table-layout: auto; border-collapse: collapse; border-spacing: 1px;';
+        const thStyle = 'border: 1px solid #dededf; background-color: #eceff1; color: #000000; padding: 5px 15px; text-align: left; height: 20.4pt; white-space: nowrap;';
+        const tdStyle = 'border: 1px solid #dededf; background-color: #ffffff; color: #000000; padding: 5px 15px; text-align: left; height: 14.4pt; white-space: nowrap;';
 
         let tableHtml = `<table style="${tableStyle}"><thead><tr>`;
 
@@ -450,7 +459,12 @@ export default class ExcelActionHandler extends StatefulActionHandler {
             case 2:
                 return this.session.Run(input.macro, input.functionParams[0], input.functionParams[1]);
             case 3:
-                return this.session.Run(input.macro, input.functionParams[0], input.functionParams[1], input.functionParams[2]);
+                return this.session.Run(
+                    input.macro,
+                    input.functionParams[0],
+                    input.functionParams[1],
+                    input.functionParams[2]
+                );
             case 4:
                 return this.session.Run(
                     input.macro,
@@ -619,7 +633,9 @@ export default class ExcelActionHandler extends StatefulActionHandler {
         if (
             (shouldExist && !this.checkIfWorksheetExist(worksheet)) ||
             (!shouldExist &&
-                (this.checkIfWorksheetExist(worksheet) || worksheet.length > 31 || !worksheet.match(RegexPatterns.EXCEL_WORKSHEET_NAME)))
+                (this.checkIfWorksheetExist(worksheet) ||
+                    worksheet.length > 31 ||
+                    !worksheet.match(RegexPatterns.EXCEL_WORKSHEET_NAME)))
         ) {
             throw new Error(ExcelErrorMessage.worksheetIncorrectInput(shouldExist));
         }
@@ -634,11 +650,12 @@ export default class ExcelActionHandler extends StatefulActionHandler {
      */
     private getDividedCellCoordinates(cell: string): CellCoordinates {
         const cellMatch = cell.match(/([A-Z]+)([0-9]+)/);
-        if (!cellMatch || cellMatch.length !== 3) throw new Error(ExcelErrorMessage.divideCellCoordinatesIncorrectInput());
+        if (!cellMatch || cellMatch.length !== 3)
+            throw new Error(ExcelErrorMessage.divideCellCoordinatesIncorrectInput());
 
         return {
             column: this.getColumnCoordinate(cellMatch[1]),
-            row: Number(cellMatch[2])
+            row: Number(cellMatch[2]),
         };
     }
 
@@ -649,7 +666,8 @@ export default class ExcelActionHandler extends StatefulActionHandler {
      * @example getColumnCoordinate('C') // 3
      */
     private getColumnCoordinate(column: string): number {
-        if (!column || typeof column === 'number') throw new Error(ExcelErrorMessage.getColumnCoordinateIncorrectInput());
+        if (!column || typeof column === 'number')
+            throw new Error(ExcelErrorMessage.getColumnCoordinateIncorrectInput());
         return this.session.ActiveSheet.Range(`${column}1`).Column;
     }
 
@@ -730,6 +748,6 @@ export default class ExcelActionHandler extends StatefulActionHandler {
     }
 
     private isNegativeInteger(number: number): boolean {
-        return Number.isInteger(number) && number < 0;
+        return (Number.isInteger(number) && number < 0)
     }
 }

--- a/office-actions/vitest.config.ts
+++ b/office-actions/vitest.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         globals: true,
-        setupFiles: ['dotenv/config'],
+        // setupFiles: ['dotenv/config'],
     },
 });

--- a/office-actions/vitest.config.ts
+++ b/office-actions/vitest.config.ts
@@ -3,6 +3,5 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     test: {
         globals: true,
-        // setupFiles: ['dotenv/config'],
     },
 });


### PR DESCRIPTION
Previously exporting to HTML caused cell formatting to be converted as value:

Now it takes the final outcome (formatting do not mess with value):

Excel:
![image](https://github.com/runbotics/runbotics-actions/assets/61866178/c26ef565-14a7-4bca-9ca3-08b804d3f995)

HTML:
![image](https://github.com/runbotics/runbotics-actions/assets/61866178/fecc0b3b-4118-4a24-800a-6e14cfcffabd)
